### PR TITLE
chore(pre-align): fill missing anchor ids on breadcrumb h2 (6 docs)

### DIFF
--- a/en/Overview.md
+++ b/en/Overview.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=453f96eb6b05 -->
+<!-- pre-align:aligned sig=94b082ffc877 -->
+
+<a id="content-delivery-cdn-overview"></a>
 
 ## Content Delivery > CDN > Overview
 

--- a/en/api-guide-v1.5.md
+++ b/en/api-guide-v1.5.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=3df7fa164214 -->
+<!-- pre-align:aligned sig=d1f02419975d -->
+
+<a id="content-delivery-cdn-api-v15-guide"></a>
 
 ## Content Delivery > CDN > API v1.5 Guide
 

--- a/en/api-guide-v2.0.md
+++ b/en/api-guide-v2.0.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=d955c506b577 -->
+<!-- pre-align:aligned sig=b50e36c2e34a -->
+
+<a id="content-delivery-cdn-api-v20-guide"></a>
 
 ## Content Delivery > CDN > API v2.0 Guide
 

--- a/en/api-guide-v3.0.md
+++ b/en/api-guide-v3.0.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=73fb7cfa0df0 -->
+<!-- pre-align:aligned sig=6a9497a9cc76 -->
+
+<a id="content-delivery-cdn-api-v30-guide"></a>
 
 ## Content Delivery > CDN > API v3.0 Guide
 

--- a/en/console-guide.md
+++ b/en/console-guide.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=34e9e26965c5 -->
+<!-- pre-align:aligned sig=9deb1697d05f -->
+
+<a id="content-delivery-cdn-console-user-guide"></a>
 
 ## Content Delivery > CDN > Console User Guide
 

--- a/en/error-code.md
+++ b/en/error-code.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=ec416b7f4d48 -->
+<!-- pre-align:aligned sig=33736e0e3daa -->
+
+<a id="content-delivery-cdn-error-codes"></a>
 
 ## Content Delivery > CDN > Error Codes
 

--- a/ja/Overview.md
+++ b/ja/Overview.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=453f96eb6b05 -->
+<!-- pre-align:aligned sig=94b082ffc877 -->
+
+<a id="content-delivery-cdn-overview"></a>
 
 ## Content Delivery > CDN > 概要
 

--- a/ja/api-guide-v1.5.md
+++ b/ja/api-guide-v1.5.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=3df7fa164214 -->
+<!-- pre-align:aligned sig=d1f02419975d -->
+
+<a id="content-delivery-cdn-api-v15-guide"></a>
 
 ## Content Delivery > CDN > API v1.5ガイド
 

--- a/ja/api-guide-v2.0.md
+++ b/ja/api-guide-v2.0.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=d955c506b577 -->
+<!-- pre-align:aligned sig=b50e36c2e34a -->
+
+<a id="content-delivery-cdn-api-v20-guide"></a>
 
 ## Content Delivery > CDN > API v2.0ガイド
 

--- a/ja/api-guide-v3.0.md
+++ b/ja/api-guide-v3.0.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=73fb7cfa0df0 -->
+<!-- pre-align:aligned sig=6a9497a9cc76 -->
+
+<a id="content-delivery-cdn-api-v30-guide"></a>
 
 ## Content Delivery > CDN > API v3.0 ガイド
 

--- a/ja/console-guide.md
+++ b/ja/console-guide.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=34e9e26965c5 -->
+<!-- pre-align:aligned sig=9deb1697d05f -->
+
+<a id="content-delivery-cdn-console-user-guide"></a>
 
 ## Content Delivery > CDN > コンソール使用ガイド
 

--- a/ja/error-code.md
+++ b/ja/error-code.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=ec416b7f4d48 -->
+<!-- pre-align:aligned sig=33736e0e3daa -->
+
+<a id="content-delivery-cdn-error-codes"></a>
 
 ## Content Delivery > CDN > エラーコード
 

--- a/ko/Overview.md
+++ b/ko/Overview.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=453f96eb6b05 -->
+<!-- pre-align:aligned sig=94b082ffc877 -->
+
+<a id="content-delivery-cdn-overview"></a>
 
 ## Content Delivery > CDN > 개요
 

--- a/ko/api-guide-v1.5.md
+++ b/ko/api-guide-v1.5.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=3df7fa164214 -->
+<!-- pre-align:aligned sig=d1f02419975d -->
+
+<a id="content-delivery-cdn-api-v15-guide"></a>
 
 ## Content Delivery > CDN > API v1.5 가이드
 

--- a/ko/api-guide-v2.0.md
+++ b/ko/api-guide-v2.0.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=d955c506b577 -->
+<!-- pre-align:aligned sig=b50e36c2e34a -->
+
+<a id="content-delivery-cdn-api-v20-guide"></a>
 
 ## Content Delivery > CDN > API v2.0 가이드
 

--- a/ko/api-guide-v3.0.md
+++ b/ko/api-guide-v3.0.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=73fb7cfa0df0 -->
+<!-- pre-align:aligned sig=6a9497a9cc76 -->
+
+<a id="content-delivery-cdn-api-v30-guide"></a>
 
 ## Content Delivery > CDN > API v3.0 가이드
 

--- a/ko/console-guide.md
+++ b/ko/console-guide.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=34e9e26965c5 -->
+<!-- pre-align:aligned sig=9deb1697d05f -->
+
+<a id="content-delivery-cdn-console-user-guide"></a>
 
 ## Content Delivery > CDN > 콘솔 사용 가이드
 

--- a/ko/error-code.md
+++ b/ko/error-code.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=ec416b7f4d48 -->
+<!-- pre-align:aligned sig=33736e0e3daa -->
+
+<a id="content-delivery-cdn-error-codes"></a>
 
 ## Content Delivery > CDN > 오류 코드
 


### PR DESCRIPTION
Manual, minimal-touch anchor-id fill on 6 docs whose top breadcrumb `## Content Delivery > CDN > …` had **no anchor id in any of ko/en/ja** on `alpha`. compare-headings flagged this as `id_diff` for every one of them (a h1..h4 heading without an anchor id is a mismatch), while the align tool's `pre-align:aligned` marker considered them aligned (ko/en/ja agreed on "no anchor") and skipped them — so `align-heading` never fixed it.

## Scope

Only id-less headings are touched. No existing anchor is renamed. `{ #id }` inline attr blocks are **not** added (matches the surrounding files' block-style anchors). Body bytes, EOL style, and existing anchors are preserved verbatim; the only per-file mutation is:

  * A new `<a id="content-delivery-cdn-<slug>"></a>` line inserted directly above the top h2.
  * The `<!-- pre-align:aligned sig=… -->` marker refreshed to the new outline hash so the next align run doesn't re-fire on these docs (verified: `has_valid_aligned_marker(text) == True` for every touched file post-change).

`release-notes.md` is intentionally omitted — [PR #88](https://github.com/TOAST-DOCS/CDN/pull/88) already fills its missing `ja` anchors and canonicalizes the whole file. Merging this PR first, then #88, cleanly composes; merging #88 first requires a trivial rebase here (only marker sig would move).

## Files touched (18 = 6 docs × ko/en/ja)

| Doc | slug |
| --- | --- |
| `Overview.md` | `content-delivery-cdn-overview` |
| `api-guide-v1.5.md` | `content-delivery-cdn-api-v15-guide` |
| `api-guide-v2.0.md` | `content-delivery-cdn-api-v20-guide` |
| `api-guide-v3.0.md` | `content-delivery-cdn-api-v30-guide` |
| `console-guide.md` | `content-delivery-cdn-console-user-guide` |
| `error-code.md` | `content-delivery-cdn-error-codes` |

Every file's diff is `+3 / -1` (add anchor + blank + refreshed marker; remove old marker). `ja/console-guide.md` retains its CRLF line endings.

## Verification

Post-change, on every one of the 18 files:

  * `align_apply.has_valid_aligned_marker(text) == True`
  * `compare_headings.compare_doc(...)` returns **0 diffs** for both `en` and `ja` legs.

## Heading compare (docs viewer)

- **Base (`alpha`)**: [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FCDN%2Ftree%2Falpha&source=ko&langs=en%2Cja)
- **This PR**: [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FCDN%2Fpull%2FNEW&source=ko&langs=en%2Cja)