### PR TITLE
fix: 앵커 ID 정규화 이후 깨진 내부 링크 수정

### DIFF
--- a/ja/console-guide.md
+++ b/ja/console-guide.md
@@ -258,7 +258,7 @@ URLベースで生成されるキャッシュキーにリクエストのクエ�
 
 > [参考] NHN Cloud Object Storageサービスで作成したコンテナをオリジンサーバーとして使用する場合
 > Large File Optimization機能が正常に動作するには、オリジンサーバーから渡される`ETag`レスポンスヘッダが二重引用符で囲まれた形式である必要があります。
-> NHN Cloud Object Storageコンテナでの`ETag`レスポンスヘッダ形式の設定に関する詳細は、Object StorageサービスのAPIガイド内の[コンテナ設定の変更 > RFCに準拠したETag形式の使用設定](../../../../ko/Storage/Object%20Storage/ko/api-guide/#_24)をご参照ください。
+> NHN Cloud Object Storageコンテナでの`ETag`レスポンスヘッダ形式の設定に関する詳細は、Object StorageサービスのAPIガイド内の[コンテナ設定の変更 > RFCに準拠したETag形式の使用設定](../../../../ja/Storage/Object%20Storage/ja/api-guide/#change-container-settings)をご参照ください。
 
 
 <a id="access-management-for-referer-header"></a>

--- a/ko/console-guide-gov.md
+++ b/ko/console-guide-gov.md
@@ -223,7 +223,7 @@ URL 기반으로 생성되는 캐시 키에 요청 쿼리 문자열을 포함할
 
 > [참고] NHN Cloud Object Storage 서비스에서 생성한 컨테이너를 원본 서버로 사용하는 경우
 > Large File Optimization 기능이 정상적으로 동작하기 위해서는 원본 서버에서 전달되는 `ETag` 응답 헤더가 큰따옴표로 묶인 형태여야 합니다.
-> NHN Cloud Object Storage 컨테이너에 `ETag` 응답 헤더 형식 설정에 대한 자세한 내용은 Object Storage 서비스의 API 가이드 내 [컨테이너 설정 변경 > RFC를 준수하는 ETag 형식 사용 설정](../../../../ko/Storage/Object%20Storage/ko/api-guide-gov/#_24)을 참고하세요.
+> NHN Cloud Object Storage 컨테이너에 `ETag` 응답 헤더 형식 설정에 대한 자세한 내용은 Object Storage 서비스의 API 가이드 내 [컨테이너 설정 변경 > RFC를 준수하는 ETag 형식 사용 설정](../../../../ko/Storage/Object%20Storage/ko/api-guide-gov/#change-container-settings)을 참고하세요.
 
 
 ### 리퍼러(referer) 헤더 접근 관리

--- a/ko/console-guide.md
+++ b/ko/console-guide.md
@@ -258,7 +258,7 @@ URL 기반으로 생성되는 캐시 키에 요청 쿼리 문자열을 포함할
 
 > [참고] NHN Cloud Object Storage 서비스에서 생성한 컨테이너를 원본 서버로 사용하는 경우
 > Large File Optimization 기능이 정상적으로 동작하기 위해서는 원본 서버에서 전달되는 `ETag` 응답 헤더가 큰따옴표로 묶인 형태여야 합니다.
-> NHN Cloud Object Storage 컨테이너에 `ETag` 응답 헤더 형식 설정에 대한 자세한 내용은 Object Storage 서비스의 API 가이드 내 [컨테이너 설정 변경 > RFC를 준수하는 ETag 형식 사용 설정](../../../../ko/Storage/Object%20Storage/ko/api-guide/#_24)을 참고하세요.
+> NHN Cloud Object Storage 컨테이너에 `ETag` 응답 헤더 형식 설정에 대한 자세한 내용은 Object Storage 서비스의 API 가이드 내 [컨테이너 설정 변경 > RFC를 준수하는 ETag 형식 사용 설정](../../../../ko/Storage/Object%20Storage/ko/api-guide/#change-container-settings)을 참고하세요.
 
 
 <a id="access-management-for-referer-header"></a>


### PR DESCRIPTION
## Summary
- 앵커 ID 정규화(30014ac) 이후 변경된 앵커를 참조하는 내부 링크 15건 수정 (ko/en/ja)
  - `#alias_domain` → `#alias-domain`
  - `#alias_domain_api` → `#alias-domain-api`
  - `#root_path_access_control` → `#controlling-the-access-of-root-path`
  - `#create-a-token` → `#access-control-for-auth-token-authentication-create-a-token`
- Object Storage API 가이드 ETag 링크 앵커 수정 (ko/ja/gov)
  - `#_24` → `#change-container-settings`
  - ja 경로 언어 세그먼트 `ko` → `ja` 수정

## Test plan
- [ ] 배포 후 release-notes, api-guide-v2.0, api-guide-v3.0, console-guide 내 수정된 링크 클릭하여 정상 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)